### PR TITLE
新增功能：第一次启用脚本时，跳过用户已经完成的内容

### DIFF
--- a/yuketang.js
+++ b/yuketang.js
@@ -938,7 +938,7 @@ ${ocrText}
         const tagHref = item.querySelector('.tag')?.querySelector('use')?.getAttribute('xlink:href') || '';
         const title = item.querySelector('h2')?.innerText || `第${idx + 1}项`;
         // 跳过已完成条目
-        const status = item.querySelector(".statistics-box")?.querySelector(".aside")?.querySelector(':scope span')?.innerText || '';
+        const status = item.querySelector('.statistics-box')?.querySelector('.aside')?.querySelector(':scope span')?.innerText || '';
         if (status === '已读' || status === '已完成' || status === '已发言') {
           this.panel.log(`${title} 已完成，跳过`);
           idx++;

--- a/yuketang.js
+++ b/yuketang.js
@@ -937,6 +937,14 @@ ${ocrText}
         const tagText = item.querySelector('.tag')?.innerText || '';
         const tagHref = item.querySelector('.tag')?.querySelector('use')?.getAttribute('xlink:href') || '';
         const title = item.querySelector('h2')?.innerText || `第${idx + 1}项`;
+        // 跳过已完成条目
+        const status = item.querySelector(".statistics-box")?.querySelector(".aside")?.querySelector(':scope span')?.innerText || '';
+        if (status === '已读' || status === '已完成' || status === '已发言') {
+          this.panel.log(`${title} 已完成，跳过`);
+          idx++;
+          this.updateProgress(this.outside, idx);
+          continue;
+        }
         if (tagText === '音频') {
           idx = await this.playAudioItem(item, title, idx);
         } else if (tagHref.includes('shipin')) {


### PR DESCRIPTION
目前，第一次启用脚本时，不会自动判断哪些内容已经完成，对于已经完成的内容，会点进去，过一段时间，再退出。因此，添加了一段代码对完成状态进行判断。