### PR TITLE
fix: 修复刷课流程中断无法恢复，并增加停止/重新加载控制

### DIFF
--- a/yuketang.js
+++ b/yuketang.js
@@ -138,6 +138,26 @@
       const elementDurationMs = duration * 1000;               // 转为秒
       const timeout = Math.max(elementDurationMs * 3, 10_000); // 至少 10 秒（防极短视频）;
       return timeout;
+    },
+    // 关闭雨课堂的挂机/离开检测弹窗，避免遮罩拦截刷课流程
+    dismissPopups() {
+      const wrappers = document.querySelectorAll('.el-dialog__wrapper, .el-message-box__wrapper');
+      for (const wrapper of wrappers) {
+        const style = getComputedStyle(wrapper);
+        const rect = wrapper.getBoundingClientRect();
+        if (style.display === 'none' || style.visibility === 'hidden' || rect.width === 0) continue;
+        const text = wrapper.innerText || '';
+        const buttons = [...wrapper.querySelectorAll('button')];
+        const clickBtn = label => {
+          const btn = buttons.find(b => (b.innerText || '').trim().includes(label));
+          if (btn) btn.click();
+        };
+        if (text.includes('好好学习') || text.includes('继续观看')) {
+          clickBtn('继续观看');
+        } else if (text.includes('报告老师')) {
+          clickBtn('取消');
+        }
+      }
     }
   };
 
@@ -670,7 +690,13 @@
     };
 
     let startHandler = null;
+    let running = false;
     const invokeStart = () => {
+      if (running) {
+        log('已在刷课中，忽略重复启动');
+        return;
+      }
+      running = true;
       log('启动中...');
       ui.btnStart.innerText = '刷课中...';
       startHandler && startHandler();
@@ -689,6 +715,7 @@
       },
       resetStartButton(text = '开始刷课') {
         ui.btnStart.innerText = text;
+        if (text !== '刷课中...') running = false;
       }
     };
   }
@@ -731,33 +758,40 @@
     },
     observePause(video, shouldResume = () => true) {
       if (!video) return () => { };
-      const target = document.getElementsByClassName('play-btn-tip')[0];
-      if (!target) return () => { };
+      const canResume = () => shouldResume() && !video.ended && !this.isNearEnd(video);
       // 自动播放
       const playVideo = () => {
-        if (!shouldResume() || video.ended || this.isNearEnd(video)) return;
+        if (!canResume()) return;
         video.play().catch(e => {
-          if (!shouldResume() || video.ended || this.isNearEnd(video)) return;
+          if (!canResume()) return;
           console.warn('自动播放失败:', e);
           setTimeout(playVideo, 3000);
         });
       };
       playVideo();
-      const observer = new MutationObserver(list => {
-        for (const mutation of list) {
-          if (
-            mutation.type === 'childList'
-            && target.innerText === '播放'
-            && shouldResume()
-            && !video.ended
-            && !this.isNearEnd(video)
-          ) {
-            video.play();
+      // 直接监听 pause 事件，不依赖播放器 UI 元素
+      const onPause = () => { if (canResume()) playVideo(); };
+      video.addEventListener('pause', onPause);
+      // 定时兜底：防止 pause 事件被拦截
+      const timer = setInterval(() => { if (video.paused && canResume()) playVideo(); }, 5000);
+      // 播放器 UI 观察：按钮被点击暂停时 tip 变为「播放」
+      const target = document.getElementsByClassName('play-btn-tip')[0];
+      let observer = null;
+      if (target) {
+        observer = new MutationObserver(list => {
+          for (const mutation of list) {
+            if (mutation.type === 'childList' && target.innerText === '播放' && canResume()) {
+              video.play();
+            }
           }
-        }
-      });
-      observer.observe(target, { childList: true });
-      return () => observer.disconnect();
+        });
+        observer.observe(target, { childList: true });
+      }
+      return () => {
+        video.removeEventListener('pause', onPause);
+        clearInterval(timer);
+        if (observer) observer.disconnect();
+      };
     },
     waitForEnd(media, timeout = 0) {
       return new Promise(resolve => {
@@ -1280,6 +1314,13 @@ ${ocrText}
         await this.autoSlide();
         const list = document.querySelector('.logs-list')?.childNodes;
         if (!list || !list.length) {
+          // 可能停留在课件页：有目录页地址时直接跳回，避免无限重试
+          const pending = Store.getPendingAutoStart();
+          if (pending?.returnUrl && !location.pathname.includes('/studentLog/')) {
+            this.panel.log('当前页面无课程列表，返回目录页继续');
+            location.href = pending.returnUrl;
+            return;
+          }
           this.panel.log('未找到课程列表，稍后重试');
           await Utils.sleep(2000);
           continue;
@@ -1353,7 +1394,10 @@ ${ocrText}
       Player.applySpeed();
       Player.mute();
       const stopObserve = Player.observePause(document.querySelector('video'));
-      await Utils.poll(() => isDeadline || Utils.isProgressDone(progressNode?.innerHTML), { interval: 5000, timeout: await Utils.getDDL() });
+      await Utils.poll(() => {
+        Utils.dismissPopups();
+        return isDeadline || Utils.isProgressDone(progressNode?.innerHTML);
+      }, { interval: 5000, timeout: await Utils.getDDL() });
       stopObserve();
       this.updateProgress(this.outside + 1, 0);
       history.back();
@@ -1418,7 +1462,10 @@ ${ocrText}
       await Utils.sleep(2500);
       Player.applyMediaDefault(document.querySelector('audio'));
       const progressNode = document.querySelector('.progress-wrap')?.querySelector('.text');
-      await Utils.poll(() => Utils.isProgressDone(progressNode?.innerHTML), { interval: 3000, timeout: await Utils.getDDL() });
+      await Utils.poll(() => {
+        Utils.dismissPopups();
+        return Utils.isProgressDone(progressNode?.innerHTML);
+      }, { interval: 3000, timeout: await Utils.getDDL() });
       this.panel.log(`${title} 播放完成`);
       idx++;
       this.updateProgress(this.outside, idx);
@@ -1436,7 +1483,10 @@ ${ocrText}
       Player.mute();
       const stopObserve = Player.observePause(document.querySelector('video'));
       const progressNode = document.querySelector('.progress-wrap')?.querySelector('.text');
-      await Utils.poll(() => Utils.isProgressDone(progressNode?.innerHTML), { interval: 3000, timeout: await Utils.getDDL() });
+      await Utils.poll(() => {
+        Utils.dismissPopups();
+        return Utils.isProgressDone(progressNode?.innerHTML);
+      }, { interval: 3000, timeout: await Utils.getDDL() });
       stopObserve();
       this.panel.log(`${title} 播放完成`);
       idx++;
@@ -1649,6 +1699,7 @@ ${ocrText}
             muteBtn && muteBtn.click();
             const stopObserve = Player.observePause(document.querySelector('video'));
             await Utils.poll(() => {
+              Utils.dismissPopups();
               const allTime = document.querySelector('.xt_video_player_current_time_display')?.innerText || '';
               const [nowTime, totalTime] = allTime.split(' / ');
               return nowTime && totalTime && nowTime === totalTime;
@@ -1665,11 +1716,14 @@ ${ocrText}
           Player.applySpeed();
           const muteBtn = document.querySelector('.xt_video_player_common_icon');
           muteBtn && muteBtn.click();
+          const stopObserve = Player.observePause(document.querySelector('video'));
           await Utils.poll(() => {
+            Utils.dismissPopups();
             const times = document.querySelector('.xt_video_player_current_time_display')?.innerText || '';
             const [nowTime, totalTime] = times.split(' / ');
             return nowTime && totalTime && nowTime === totalTime;
           }, { interval: 800, timeout: await Utils.getDDL() });
+          stopObserve();
           this.panel.log(`${className} 视频播放完毕`);
         }
       }
@@ -1784,6 +1838,7 @@ ${ocrText}
           localStorage.removeItem(Config.storageKeys.proClassCount);
           this.panel.log('课程播放完毕 🎉');
           Store.clearPendingAutoStart();
+          this.panel.resetStartButton('开始刷课');
           break;
         }
       }

--- a/yuketang.js
+++ b/yuketang.js
@@ -449,6 +449,12 @@
               #btn-setting {
                 background-color: #52c41a;
               }
+              #btn-stop {
+                background-color: #8c8c8c;
+              }
+              #btn-reload {
+                background-color: #fa8c16;
+              }
 
               /* 设置页底部按钮 */
               .settings-footer {
@@ -544,6 +550,8 @@
                 <button id="btn-setting">AI配置</button>
                 <button id="btn-clear">清除缓存</button>
                 <button id="btn-start">开始刷课</button>
+                <button id="btn-stop">停止刷课</button>
+                <button id="btn-reload">重新加载</button>
               </div>
             </div>
     `);
@@ -558,6 +566,8 @@
       btnStart: doc.getElementById('btn-start'),
       btnClear: doc.getElementById('btn-clear'),
       btnSetting: doc.getElementById('btn-setting'),
+      btnStop: doc.getElementById('btn-stop'),
+      btnReload: doc.getElementById('btn-reload'),
       settings: doc.getElementById('settings'),
       saveSettings: doc.getElementById('save_settings'),
       closeSettings: doc.getElementById('close_settings'),
@@ -687,6 +697,20 @@
       localStorage.removeItem(Config.storageKeys.proClassCount);
       Store.clearPendingAutoStart();
       log('已清除当前课程的刷课进度缓存');
+    };
+
+    // 停止刷课：清除自动恢复标记后刷新页面，刷新后脚本回到空闲状态（进度缓存保留）
+    ui.btnStop.onclick = () => {
+      Store.clearPendingAutoStart();
+      log('已停止刷课，页面即将刷新');
+      window.parent.location.reload();
+    };
+
+    // 重新加载：重建自动恢复标记后刷新页面，刷新后自动恢复刷课（停止后点击同样生效）
+    ui.btnReload.onclick = () => {
+      Store.setPendingAutoStart(Utils.getCurrentClassroomId());
+      log('正在重新加载脚本...');
+      window.parent.location.reload();
     };
 
     let startHandler = null;
@@ -1310,15 +1334,28 @@ ${ocrText}
 
     async run() {
       this.panel.log(`检测到已播放到第 ${this.outside} 集，继续刷课...`);
+      // 在课件页恢复时直接续播当前内容，不重新走列表流程
+      if (location.pathname.includes('/studentCards/')) {
+        const videoBox = document.querySelector('.video-box');
+        const boxText = videoBox?.innerText || '';
+        if ((videoBox || document.querySelector('video')) && !boxText.includes('已完成')) {
+          this.panel.log('检测到当前课件页，直接续播当前内容');
+          await this.waitCoursewareVideo();
+          history.back();
+          await Utils.sleep(1000);
+        }
+      }
       while (true) {
         await this.autoSlide();
         const list = document.querySelector('.logs-list')?.childNodes;
         if (!list || !list.length) {
-          // 可能停留在课件页：有目录页地址时直接跳回，避免无限重试
+          // 可能停留在课件页：跳回目录页继续，避免无限重试
           const pending = Store.getPendingAutoStart();
-          if (pending?.returnUrl && !location.pathname.includes('/studentLog/')) {
+          const returnUrl = pending?.returnUrl
+            || (pending?.classroomId ? `/v2/web/studentLog/${pending.classroomId}` : '');
+          if (returnUrl && !location.pathname.includes('/studentLog/')) {
             this.panel.log('当前页面无课程列表，返回目录页继续');
-            location.href = pending.returnUrl;
+            location.href = returnUrl;
             return;
           }
           this.panel.log('未找到课程列表，稍后重试');

--- a/yuketang.js
+++ b/yuketang.js
@@ -1655,6 +1655,59 @@ ${ocrText}
       await Utils.sleep(1200);
     }
 
+    // 等待课件视频播放完毕；播放器被关闭（弹窗关闭/元素销毁）时自动重新打开
+    async waitCoursewareVideo() {
+      const deadline = await Utils.getDDL();
+      const start = Date.now();
+      let boundVideo = null;
+      let stopObserve = () => { };
+      let reopenAttempts = 0;
+      try {
+        while (Date.now() - start < deadline) {
+          Utils.dismissPopups();
+          const video = document.querySelector('video');
+          const display = document.querySelector('.xt_video_player_current_time_display');
+          if (!video) {
+            // 播放器被关闭或视频元素被销毁，重新打开视频框
+            const videoBox = document.querySelector('.video-box');
+            if (videoBox && !videoBox.innerText.includes('已完成')) {
+              this.panel.log('播放器被关闭，正在重新打开');
+              videoBox.click();
+              boundVideo = null;
+            }
+            reopenAttempts++;
+            if (reopenAttempts >= 4) {
+              this.panel.log('播放器恢复失败，刷新页面重试');
+              location.reload();
+              return false;
+            }
+            await Utils.sleep(2000);
+            continue;
+          }
+          reopenAttempts = 0;
+          if (!display) {
+            // 播放器加载中，等待渲染
+            await Utils.sleep(800);
+            continue;
+          }
+          if (video !== boundVideo) {
+            stopObserve();
+            Player.applySpeed();
+            Player.mute();
+            boundVideo = video;
+            stopObserve = Player.observePause(video);
+          }
+          const times = display.innerText || '';
+          const [nowTime, totalTime] = times.split(' / ');
+          if (nowTime && totalTime && nowTime === totalTime) return true;
+          await Utils.sleep(800);
+        }
+        return false;
+      } finally {
+        stopObserve();
+      }
+    }
+
     async handleCourseware(course) {
       const tableData = course.parentNode?.parentNode?.parentNode?.__vue__?.tableData;
       const deadlinePassed = (tableData?.deadline || tableData?.end) ? (tableData.deadline < Date.now() || tableData.end < Date.now()) : false;
@@ -1694,17 +1747,7 @@ ${ocrText}
             }
             videoBoxes[i].click();
             await Utils.sleep(2000);
-            Player.applySpeed();
-            const muteBtn = document.querySelector('.xt_video_player_common_icon');
-            muteBtn && muteBtn.click();
-            const stopObserve = Player.observePause(document.querySelector('video'));
-            await Utils.poll(() => {
-              Utils.dismissPopups();
-              const allTime = document.querySelector('.xt_video_player_current_time_display')?.innerText || '';
-              const [nowTime, totalTime] = allTime.split(' / ');
-              return nowTime && totalTime && nowTime === totalTime;
-            }, { interval: 800, timeout: await Utils.getDDL() });
-            stopObserve();
+            await this.waitCoursewareVideo();
           }
         }
         this.panel.log(`${className} 已播放完毕`);
@@ -1713,17 +1756,7 @@ ${ocrText}
         if (videoBox) {
           videoBox.click();
           await Utils.sleep(1800);
-          Player.applySpeed();
-          const muteBtn = document.querySelector('.xt_video_player_common_icon');
-          muteBtn && muteBtn.click();
-          const stopObserve = Player.observePause(document.querySelector('video'));
-          await Utils.poll(() => {
-            Utils.dismissPopups();
-            const times = document.querySelector('.xt_video_player_current_time_display')?.innerText || '';
-            const [nowTime, totalTime] = times.split(' / ');
-            return nowTime && totalTime && nowTime === totalTime;
-          }, { interval: 800, timeout: await Utils.getDDL() });
-          stopObserve();
+          await this.waitCoursewareVideo();
           this.panel.log(`${className} 视频播放完毕`);
         }
       }


### PR DESCRIPTION
## 问题

脚本运行过程中，视频暂停、弹窗出现、课件视频弹窗被关闭等场景下，刷课状态无法自行恢复：

- 单视频课件分支没有挂载防暂停监听，视频暂停后无人恢复，最长等待 3 倍视频时长后静默跳过（进度不涨）
- 挂机/离开检测弹窗带 v-modal 遮罩，拦截课程点击，脚本对弹窗零处理
- 课件页刷新后恢复逻辑陷入「未找到课程列表」无限重试
- 自动恢复与手动点击可叠加出两个 runner 互相竞态
- 课件视频以弹窗（浮动窗口）播放时，关闭弹窗后视频元素被销毁/暂停，播放无法恢复
- 缺少停止/退出控制，无法随时中断刷课

## 修改

- 强化 observePause：直接监听 pause 事件 + 5 秒定时兜底，不再依赖播放器 UI 元素
- 单视频课件分支补挂 observePause
- 新增 Utils.dismissPopups()：自动点击「继续观看」/「取消」关闭挂机检测与报告弹窗，接入所有轮询
- 课件页无课程列表时跳回目录页（returnUrl 为空时用 classroomId 构造地址兜底），避免无限重试
- invokeStart 增加 running 标志防止重复启动
- 新增 waitCoursewareVideo：播放器被关闭时自动重新打开视频框；视频元素被替换时重新绑定 observePause 并恢复播放；多次重开失败后自动刷新页面配合自动恢复
- 面板新增「停止刷课」按钮：清除自动恢复标记后刷新页面，刷新后脚本空闲（进度缓存保留）
- 面板新增「重新加载」按钮：重建自动恢复标记后刷新页面，在原课件页直接续播当前内容，不重新走列表流程

## 验证

在长江雨课堂（changjiang.yuketang.cn）真实账号上实测：

- 人为暂停视频 → 2 秒内自动恢复播放
- 触发「好好学习」弹窗 → 4 秒内自动点击「继续观看」关闭，遮罩消失
- 连点开始按钮 → 第二次启动被忽略，单 runner
- 课件页刷新 → 自动恢复单 runner 直接续刷，无死循环
- 销毁视频元素（模拟弹窗关闭）→ 新视频元素被自动接管并恢复播放；无新元素时自动刷新页面并从进度恢复
- 停止刷课 → 刷新后空闲不自动续刷；重新加载 → 在原课件页直接续播当前视频（不走列表流程）

🤖 Generated with [Claude Code](https://claude.com/claude-code)